### PR TITLE
Add basic tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes credentials package.json",
     "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json"
+    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json",
+    "test": "npm run build && node --test"
   },
   "files": [
     "dist"

--- a/test/fints-api.test.js
+++ b/test/fints-api.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { FintsApi } from '../dist/credentials/FintsApi.credentials.js';
+import { test } from 'node:test';
+
+test('FintsApi exposes userId and pin properties', () => {
+  const creds = new FintsApi();
+  assert.equal(creds.name, 'fintsApi');
+  const propNames = creds.properties.map(p => p.name);
+  assert.ok(propNames.includes('userId'), 'userId property missing');
+  assert.ok(propNames.includes('pin'), 'pin property missing');
+});

--- a/test/fints-node-description.test.js
+++ b/test/fints-node-description.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { FintsNode } from '../dist/nodes/FintsNode/FintsNode.node.js';
+import { test } from 'node:test';
+
+test('FintsNode has correct description properties', () => {
+  const node = new FintsNode();
+  assert.equal(node.description.displayName, 'FinTS Account Balance');
+  assert.equal(node.description.name, 'fintsNode');
+  const cred = node.description.credentials.find(c => c.name === 'fintsApi');
+  assert.ok(cred, 'fintsApi credentials missing');
+});


### PR DESCRIPTION
## Summary
- add node tests for description and credential properties
- expose test script in `package.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683bfc6e648c833193248a51e11e8343