### PR TITLE
Add date range selection for statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,23 @@ Once you have these details, create new credentials in n8n under **Settings → 
 2. **Select** the FinTS credentials you created.
 3. **Choose** the operation: **Get Account Balance**.
 4. **Configure** the parameters by selecting the desired account or providing the account number.
-5. **Execute** the workflow to receive a response object containing `balance`,`currency`, `bank`, and `account`.
+5. **Optionally**, set **Start Date** and **End Date** to limit the booking range. If left empty, the node fetches statements from the last 14 days up to today.
+6. **Execute** the workflow to receive a response object containing `balance`,`currency`, `bank`, `account`, and an array of `transactions`.
 
 ```json
 [
-	{
-		"account": "DEXXXXXXXXXX",
-		"bank": "23445561",
-		"balance": 10001,
-		"currency": "EUR"
-	}	
+        {
+                "account": "DEXXXXXXXXXX",
+                "bank": "23445561",
+                "balance": 10001,
+                "currency": "EUR",
+                "transactions": [
+                        {
+                                "amount": -20,
+                                "description": "Some payment"
+                        }
+                ]
+        }
 ]
 ```
 


### PR DESCRIPTION
## Summary
- expose `startDate` and `endDate` parameters on FinTS node
- use the provided range when requesting statements
- return statement transactions in node output
- document how to set the date range and output format

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683e977dd33c83318c5b3d3c3a370b3c