### PR TITLE
Add Sparda and PSD bank support

### DIFF
--- a/nodes/FintsNode/FintsNode.node.ts
+++ b/nodes/FintsNode/FintsNode.node.ts
@@ -51,7 +51,9 @@ export class FintsNode implements INodeType {
 					{ name: 'NordLB', value: 'NordLB' },
 					{ name: 'NRW Bank', value: 'NRW Bank' },
 					{ name: 'Postbank', value: 'Postbank' },
+					{ name: 'PSD Bank', value: 'PSD Bank' },
 					{ name: 'Santander', value: 'Santander' },
+					{ name: 'Sparda Bank', value: 'Sparda Bank' },
 					{ name: 'Targobank', value: 'Targobank' },
 					{ name: 'Volksbanken', value: 'Volksbanken' },
 				],
@@ -185,9 +187,17 @@ export class FintsNode implements INodeType {
 					blz = '10010010';
 					fintsUrl = 'https://fints.postbank.de/fints';
 					break;
+				case 'PSD Bank':
+					blz = '76060055';
+					fintsUrl = 'https://fints.psd.de/fints';
+					break;
 				case 'Santander':
 					blz = '50033300';
 					fintsUrl = 'https://fints.santander.de/fints';
+					break;
+				case 'Sparda Bank':
+					blz = '37060590';
+					fintsUrl = 'https://fints.sparda-west.de/fints';
 					break;
 				case 'Targobank':
 					blz = '30020900';

--- a/test/fints-node-description.test.js
+++ b/test/fints-node-description.test.js
@@ -10,5 +10,5 @@ test('FintsNode has correct description properties', () => {
   assert.ok(cred, 'fintsApi credentials missing');
   const bankProp = node.description.properties.find(p => p.name === 'bank');
   assert.ok(bankProp, 'bank property missing');
-  assert.equal(bankProp.options.length, 20, 'should expose 20 bank options');
+  assert.equal(bankProp.options.length, 22, 'should expose 22 bank options');
 });


### PR DESCRIPTION
## Summary
- support Sparda Bank and PSD Bank in FinTS node
- expect 22 banks in tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686db895ab2483319f47166fa722c3f4