### PR TITLE
Externalize bank list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To authenticate with your bank's FinTS server, you need:
 - **PIN**: Your Personal Identification Number.
 
 The Bank Code (BLZ) and FinTS server URL are set via the node parameters or by choosing your bank during credential setup.
+The available banks are defined in `nodes/FintsNode/banks.json`. To support additional institutions, add an entry with `value`, `displayName`, `blz`, and `fintsUrl` to this file and rebuild the project.
 
 Once you have these details, create new credentials in n8n under **Settings → API Credentials**, select **FinTS**, and enter the above information.
 

--- a/nodes/FintsNode/FintsNode.node.ts
+++ b/nodes/FintsNode/FintsNode.node.ts
@@ -9,6 +9,16 @@ import {
 
 // Use the 'fints' package (npm install fints)
 import { PinTanClient, PinTanClientConfig } from 'fints';
+import banks from './banks.json';
+
+const bankOptions = banks.map((b) => ({ name: b.displayName, value: b.value }));
+const bankMap: Record<string, { blz: string; fintsUrl: string }> = banks.reduce(
+	(acc, b) => {
+		acc[b.value] = { blz: b.blz, fintsUrl: b.fintsUrl };
+		return acc;
+	},
+	{} as Record<string, { blz: string; fintsUrl: string }>,
+);
 
 export class FintsNode implements INodeType {
 	description: INodeTypeDescription = {
@@ -33,30 +43,7 @@ export class FintsNode implements INodeType {
 				default: 'ING',
 				description: 'Select your bank. BLZ and FinTS URL will be set automatically.',
 				name: 'bank',
-				options: [
-					{ name: 'BayernLB', value: 'BayernLB' },
-					{ name: 'Comdirect', value: 'Comdirect' },
-					{ name: 'Commerzbank', value: 'Commerzbank' },
-					{ name: 'Consorsbank', value: 'Consorsbank' },
-					{ name: 'Deutsche Apotheker- Und Ärztebank', value: 'Apobank' },
-					{ name: 'Deutsche Bank', value: 'Deutsche Bank' },
-					{ name: 'DKB', value: 'DKB' },
-					{ name: 'DZ Bank', value: 'DZ Bank' },
-					{ name: 'Helaba', value: 'Helaba' },
-					{ name: 'HypoVereinsbank', value: 'HypoVereinsbank' },
-					{ name: 'ING', value: 'ING' },
-					{ name: 'KfW', value: 'KfW' },
-					{ name: 'Landesbank Berlin', value: 'Landesbank Berlin' },
-					{ name: 'LBBW', value: 'LBBW' },
-					{ name: 'NordLB', value: 'NordLB' },
-					{ name: 'NRW Bank', value: 'NRW Bank' },
-					{ name: 'Postbank', value: 'Postbank' },
-					{ name: 'PSD Bank', value: 'PSD Bank' },
-					{ name: 'Santander', value: 'Santander' },
-					{ name: 'Sparda Bank', value: 'Sparda Bank' },
-					{ name: 'Targobank', value: 'Targobank' },
-					{ name: 'Volksbanken', value: 'Volksbanken' },
-				],
+				options: bankOptions,
 				type: 'options',
 			},
 			{
@@ -126,98 +113,12 @@ export class FintsNode implements INodeType {
 			fintsUrl = this.getNodeParameter('fintsUrl', 0) as string;
 		} else {
 			const bank = this.getNodeParameter('bank', 0) as string;
-			switch (bank) {
-				case 'ING':
-					blz = '50010517';
-					fintsUrl = 'https://fints.ing.de/fints';
-					break;
-				case 'DKB':
-					blz = '12030000';
-					fintsUrl = 'https://banking-dkb.s-fints-pt-dkb.de/fints30';
-					break;
-				case 'Commerzbank':
-					blz = '10040000';
-					fintsUrl = 'https://fints.commerzbank.de/fints';
-					break;
-				case 'Comdirect':
-					blz = '20041155';
-					fintsUrl = 'https://fints.comdirect.de/fints';
-					break;
-				case 'Volksbanken':
-					blz = '76090000';
-					fintsUrl = 'https://fints.vr.de/fints';
-					break;
-				case 'Deutsche Bank':
-					blz = '50070010';
-					fintsUrl = 'https://fints.deutsche-bank.de/fints';
-					break;
-				case 'DZ Bank':
-					blz = '50060400';
-					fintsUrl = 'https://fints.dzbank.de/fints';
-					break;
-				case 'KfW':
-					blz = '50020400';
-					fintsUrl = 'https://fints.kfw.de/fints';
-					break;
-				case 'HypoVereinsbank':
-					blz = '70020270';
-					fintsUrl = 'https://fints.hypovereinsbank.de/fints';
-					break;
-				case 'LBBW':
-					blz = '60050101';
-					fintsUrl = 'https://fints.lbbw.de/fints';
-					break;
-				case 'BayernLB':
-					blz = '70050000';
-					fintsUrl = 'https://fints.bayernlb.de/fints';
-					break;
-				case 'Helaba':
-					blz = '50050200';
-					fintsUrl = 'https://fints.helaba.de/fints';
-					break;
-				case 'NordLB':
-					blz = '25050000';
-					fintsUrl = 'https://fints.nordlb.de/fints';
-					break;
-				case 'Landesbank Berlin':
-					blz = '10050000';
-					fintsUrl = 'https://fints.lbb.de/fints';
-					break;
-				case 'NRW Bank':
-					blz = '37050000';
-					fintsUrl = 'https://fints.nrwbank.de/fints';
-					break;
-				case 'Apobank':
-					blz = '30060601';
-					fintsUrl = 'https://fints.apobank.de/fints';
-					break;
-				case 'Postbank':
-					blz = '10010010';
-					fintsUrl = 'https://fints.postbank.de/fints';
-					break;
-				case 'PSD Bank':
-					blz = '76060055';
-					fintsUrl = 'https://fints.psd.de/fints';
-					break;
-				case 'Santander':
-					blz = '50033300';
-					fintsUrl = 'https://fints.santander.de/fints';
-					break;
-				case 'Sparda Bank':
-					blz = '37060590';
-					fintsUrl = 'https://fints.sparda-west.de/fints';
-					break;
-				case 'Targobank':
-					blz = '30020900';
-					fintsUrl = 'https://fints.targobank.de/fints';
-					break;
-				case 'Consorsbank':
-					blz = '76030080';
-					fintsUrl = 'https://fints.consorsbank.de/fints';
-					break;
-				default:
-					throw new NodeOperationError(this.getNode(), `Unknown bank: ${bank}`);
+			const entry = bankMap[bank];
+			if (!entry) {
+				throw new NodeOperationError(this.getNode(), `Unknown bank: ${bank}`);
 			}
+			blz = entry.blz;
+			fintsUrl = entry.fintsUrl;
 		}
 
 		const startDateStr = this.getNodeParameter('startDate', 0, '') as string;

--- a/nodes/FintsNode/banks.json
+++ b/nodes/FintsNode/banks.json
@@ -1,0 +1,134 @@
+[
+	{
+		"value": "BayernLB",
+		"displayName": "BayernLB",
+		"blz": "70050000",
+		"fintsUrl": "https://fints.bayernlb.de/fints"
+	},
+	{
+		"value": "Comdirect",
+		"displayName": "Comdirect",
+		"blz": "20041155",
+		"fintsUrl": "https://fints.comdirect.de/fints"
+	},
+	{
+		"value": "Commerzbank",
+		"displayName": "Commerzbank",
+		"blz": "10040000",
+		"fintsUrl": "https://fints.commerzbank.de/fints"
+	},
+	{
+		"value": "Consorsbank",
+		"displayName": "Consorsbank",
+		"blz": "76030080",
+		"fintsUrl": "https://fints.consorsbank.de/fints"
+	},
+	{
+		"value": "Apobank",
+		"displayName": "Deutsche Apotheker- Und Ärztebank",
+		"blz": "30060601",
+		"fintsUrl": "https://fints.apobank.de/fints"
+	},
+	{
+		"value": "Deutsche Bank",
+		"displayName": "Deutsche Bank",
+		"blz": "50070010",
+		"fintsUrl": "https://fints.deutsche-bank.de/fints"
+	},
+	{
+		"value": "DKB",
+		"displayName": "DKB",
+		"blz": "12030000",
+		"fintsUrl": "https://banking-dkb.s-fints-pt-dkb.de/fints30"
+	},
+	{
+		"value": "DZ Bank",
+		"displayName": "DZ Bank",
+		"blz": "50060400",
+		"fintsUrl": "https://fints.dzbank.de/fints"
+	},
+	{
+		"value": "Helaba",
+		"displayName": "Helaba",
+		"blz": "50050200",
+		"fintsUrl": "https://fints.helaba.de/fints"
+	},
+	{
+		"value": "HypoVereinsbank",
+		"displayName": "HypoVereinsbank",
+		"blz": "70020270",
+		"fintsUrl": "https://fints.hypovereinsbank.de/fints"
+	},
+	{
+		"value": "ING",
+		"displayName": "ING",
+		"blz": "50010517",
+		"fintsUrl": "https://fints.ing.de/fints"
+	},
+	{
+		"value": "KfW",
+		"displayName": "KfW",
+		"blz": "50020400",
+		"fintsUrl": "https://fints.kfw.de/fints"
+	},
+	{
+		"value": "Landesbank Berlin",
+		"displayName": "Landesbank Berlin",
+		"blz": "10050000",
+		"fintsUrl": "https://fints.lbb.de/fints"
+	},
+	{
+		"value": "LBBW",
+		"displayName": "LBBW",
+		"blz": "60050101",
+		"fintsUrl": "https://fints.lbbw.de/fints"
+	},
+	{
+		"value": "NordLB",
+		"displayName": "NordLB",
+		"blz": "25050000",
+		"fintsUrl": "https://fints.nordlb.de/fints"
+	},
+	{
+		"value": "NRW Bank",
+		"displayName": "NRW Bank",
+		"blz": "37050000",
+		"fintsUrl": "https://fints.nrwbank.de/fints"
+	},
+	{
+		"value": "Postbank",
+		"displayName": "Postbank",
+		"blz": "10010010",
+		"fintsUrl": "https://fints.postbank.de/fints"
+	},
+	{
+		"value": "PSD Bank",
+		"displayName": "PSD Bank",
+		"blz": "76060055",
+		"fintsUrl": "https://fints.psd.de/fints"
+	},
+	{
+		"value": "Santander",
+		"displayName": "Santander",
+		"blz": "50033300",
+		"fintsUrl": "https://fints.santander.de/fints"
+	},
+	{
+		"value": "Sparda Bank",
+		"displayName": "Sparda Bank",
+		"blz": "37060590",
+		"fintsUrl": "https://fints.sparda-west.de/fints"
+	},
+	{
+		"value": "Targobank",
+		"displayName": "Targobank",
+		"blz": "30020900",
+		"fintsUrl": "https://fints.targobank.de/fints"
+	},
+	{
+		"value": "Volksbanken",
+		"displayName": "Volksbanken",
+		"blz": "76090000",
+		"fintsUrl": "https://fints.vr.de/fints"
+	}
+]

--- a/test/fints-node-description.test.js
+++ b/test/fints-node-description.test.js
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import { FintsNode } from '../dist/nodes/FintsNode/FintsNode.node.js';
 import { test } from 'node:test';
 
-test('FintsNode has correct description properties', () => {
+test('FintsNode has correct description properties', async () => {
+  const { default: banks } = await import('../dist/nodes/FintsNode/banks.json', { with: { type: 'json' } });
   const node = new FintsNode();
   assert.equal(node.description.displayName, 'FinTS Account Balance');
   assert.equal(node.description.name, 'fintsNode');
@@ -10,5 +11,5 @@ test('FintsNode has correct description properties', () => {
   assert.ok(cred, 'fintsApi credentials missing');
   const bankProp = node.description.properties.find(p => p.name === 'bank');
   assert.ok(bankProp, 'bank property missing');
-  assert.equal(bankProp.options.length, 22, 'should expose 22 bank options');
+  assert.equal(bankProp.options.length, banks.length, `should expose ${banks.length} bank options`);
 });


### PR DESCRIPTION
## Summary
- move bank list to new `banks.json`
- generate options from JSON
- load bank data from JSON at runtime
- adjust tests to load JSON via dynamic import
- document how to extend the bank list

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688144fb72f483318489a48772bb9f4a