### PR TITLE
refactor: adopt declarative routing for FinTS node

### DIFF
--- a/nodes/FintsNode/FintsNode.node.ts
+++ b/nodes/FintsNode/FintsNode.node.ts
@@ -1,24 +1,273 @@
-import {
-	IExecuteFunctions,
-	INodeExecutionData,
-	INodeType,
-	INodeTypeDescription,
-	NodeConnectionType,
-	NodeOperationError,
+import type {
+        IDataObject,
+        IExecutePaginationFunctions,
+        IExecuteSingleFunctions,
+        IHttpRequestOptions,
+        INodeExecutionData,
+        INodeType,
+        INodeTypeDescription,
+        IN8nRequestOperations,
+        PostReceiveAction,
+        PreSendAction,
 } from 'n8n-workflow';
+import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 
 // Use the 'fints' package (npm install fints)
-import { PinTanClient, PinTanClientConfig } from 'fints';
+import { PinTanClient } from 'fints';
+import type {
+        PinTanClientConfig,
+        SEPAAccount,
+        Statement,
+        StructuredDescription,
+        Transaction,
+} from 'fints';
 import banks from './banks.json';
 
 const bankOptions = banks.map((b) => ({ name: b.displayName, value: b.value }));
 const bankMap: Record<string, { blz: string; fintsUrl: string }> = banks.reduce(
-	(acc, b) => {
-		acc[b.value] = { blz: b.blz, fintsUrl: b.fintsUrl };
-		return acc;
-	},
-	{} as Record<string, { blz: string; fintsUrl: string }>,
+        (acc, b) => {
+                acc[b.value] = { blz: b.blz, fintsUrl: b.fintsUrl };
+                return acc;
+        },
+        {} as Record<string, { blz: string; fintsUrl: string }>,
 );
+
+const DEFAULT_LOOKBACK_DAYS = 14;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type BankConfiguration = { blz: string; fintsUrl: string };
+
+interface TransactionSummary extends IDataObject {
+        currency: string | null;
+        amount: number;
+        valueDate: string | Date;
+        text?: string;
+        reference?: string;
+        isCredit: boolean;
+        isExpense: boolean;
+}
+
+interface AccountSummary extends IDataObject {
+        account: string | null;
+        bank: string;
+        balance: number | null;
+        currency: string | null;
+        transactions: TransactionSummary[];
+}
+
+interface FintsRequestMetadata {
+        config: PinTanClientConfig;
+        bankCode: string;
+        startDate: Date;
+        endDate: Date;
+}
+
+type FintsHttpRequestOptions = IHttpRequestOptions & { fints?: FintsRequestMetadata };
+
+type FintsCredentialData = { userId: string; pin: string };
+
+const prepareFintsRequest: PreSendAction = async function (
+        this: IExecuteSingleFunctions,
+        requestOptions,
+) {
+        const itemIndex = this.getItemIndex();
+        const extendedOptions = requestOptions as FintsHttpRequestOptions;
+        extendedOptions.fints = await buildFintsRequestMetadata(this, itemIndex);
+        return extendedOptions;
+};
+
+const attachPairedItem: PostReceiveAction = async function (this: IExecuteSingleFunctions, items) {
+        const itemIndex = this.getItemIndex();
+        return items.map((item) => ({
+                ...item,
+                pairedItem: { item: itemIndex },
+        }));
+};
+
+const runAccountStatementRequest: NonNullable<IN8nRequestOperations['pagination']> = async function (
+        this: IExecutePaginationFunctions,
+        requestOptions,
+): Promise<INodeExecutionData[]> {
+        const itemIndex = this.getItemIndex();
+        const options = requestOptions.options as FintsHttpRequestOptions | undefined;
+        const metadata = options?.fints ?? (await buildFintsRequestMetadata(this, itemIndex));
+        const client = new PinTanClient(metadata.config);
+        const accounts = await client.accounts();
+
+        if (!accounts.length) {
+                throw new NodeOperationError(this.getNode(), 'No accounts found', { itemIndex });
+        }
+
+        const summaries = await collectAccountSummaries(this, client, accounts, metadata);
+
+        if (options?.fints) {
+                delete options.fints;
+        }
+
+        return summaries.map((summary) => ({ json: summary }));
+};
+
+async function buildFintsRequestMetadata(
+        context: IExecuteSingleFunctions,
+        itemIndex: number,
+): Promise<FintsRequestMetadata> {
+        const credentials = await context.getCredentials<FintsCredentialData>('fintsApi', itemIndex);
+        const { blz, fintsUrl } = resolveBankConfiguration(context, itemIndex);
+        const fintsProductId = (context.getNodeParameter('fintsProductId', '') as string).trim();
+
+        const config: PinTanClientConfig = {
+                url: fintsUrl,
+                name: credentials.userId,
+                pin: credentials.pin,
+                blz,
+        };
+
+        if (fintsProductId !== '') {
+                config.productId = fintsProductId;
+        }
+
+        const { startDate, endDate } = resolveDateRange(context, itemIndex);
+
+        return {
+                config,
+                bankCode: blz,
+                startDate,
+                endDate,
+        };
+}
+
+function resolveBankConfiguration(
+        context: IExecuteSingleFunctions,
+        itemIndex: number,
+): BankConfiguration {
+        const expertMode = context.getNodeParameter('expertMode', false) as boolean;
+
+        if (expertMode) {
+                const blz = (context.getNodeParameter('blz', '') as string).trim();
+                const fintsUrl = (context.getNodeParameter('fintsUrl', '') as string).trim();
+
+                if (blz === '' || fintsUrl === '') {
+                        throw new NodeOperationError(
+                                context.getNode(),
+                                'BLZ and FinTS URL are required when expert mode is enabled.',
+                                { itemIndex },
+                        );
+                }
+
+                return { blz, fintsUrl };
+        }
+
+        const bank = context.getNodeParameter('bank') as string;
+        const configuration = bankMap[bank];
+
+        if (!configuration) {
+                throw new NodeOperationError(context.getNode(), `Unknown bank: ${bank}`, { itemIndex });
+        }
+
+        return configuration;
+}
+
+function resolveDateRange(context: IExecuteSingleFunctions, itemIndex: number) {
+        const startDateValue = context.getNodeParameter('startDate', '') as string;
+        const endDateValue = context.getNodeParameter('endDate', '') as string;
+
+        const endDate =
+                endDateValue !== ''
+                        ? parseDateParameter(context, endDateValue, 'End Date', itemIndex)
+                        : new Date();
+
+        const startDate =
+                startDateValue !== ''
+                        ? parseDateParameter(context, startDateValue, 'Start Date', itemIndex)
+                        : new Date(endDate.getTime() - DEFAULT_LOOKBACK_DAYS * MILLISECONDS_PER_DAY);
+
+        return { startDate, endDate };
+}
+
+function parseDateParameter(
+        context: IExecuteSingleFunctions,
+        value: string,
+        parameterName: string,
+        itemIndex: number,
+): Date {
+        const date = new Date(value);
+
+        if (Number.isNaN(date.getTime())) {
+                throw new NodeOperationError(
+                        context.getNode(),
+                        `${parameterName} must be a valid date.`,
+                        { itemIndex },
+                );
+        }
+
+        return date;
+}
+
+async function collectAccountSummaries(
+        context: IExecuteSingleFunctions,
+        client: PinTanClient,
+        accounts: SEPAAccount[],
+        metadata: FintsRequestMetadata,
+): Promise<AccountSummary[]> {
+        const summaries: AccountSummary[] = [];
+
+        for (const account of accounts) {
+                try {
+                        const statements = await client.statements(account, metadata.startDate, metadata.endDate);
+                        summaries.push(toAccountSummary(account, statements, metadata.bankCode));
+                } catch (error) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        context.logger.warn(message);
+                }
+        }
+
+        return summaries;
+}
+
+function toAccountSummary(
+        account: SEPAAccount,
+        statements: Statement[],
+        bankCode: string,
+): AccountSummary {
+        const latest = statements[0];
+        const balance = latest?.closingBalance?.value ?? null;
+        const currency = latest?.closingBalance?.currency ?? null;
+        const transactions = latest ? mapTransactions(latest.transactions) : [];
+
+        return {
+                account: account.iban || account.accountNumber || null,
+                bank: bankCode,
+                balance,
+                currency,
+                transactions,
+        };
+}
+
+function mapTransactions(transactions: Transaction[]): TransactionSummary[] {
+        return transactions.map((transaction) => ({
+                currency: transaction.currency ?? null,
+                amount: transaction.isCredit ? transaction.amount : -transaction.amount,
+                valueDate: transaction.valueDate,
+                text: resolveTransactionText(transaction.descriptionStructured),
+                reference: transaction.bankReference,
+                isCredit: transaction.isCredit,
+                isExpense: transaction.isExpense,
+        }));
+}
+
+function resolveTransactionText(description?: StructuredDescription): string | undefined {
+        if (!description) {
+                return undefined;
+        }
+
+        const name = description.name?.trim();
+
+        if (name && name !== '') {
+                return name;
+        }
+
+        return description.text;
+}
 
 export class FintsNode implements INodeType {
 	description: INodeTypeDescription = {
@@ -38,177 +287,146 @@ export class FintsNode implements INodeType {
 		inputs: [NodeConnectionType.Main],
 		name: 'fintsNode',
 		outputs: [NodeConnectionType.Main],
-		properties: [
-			{
-				displayName: 'Select Bank',
-				default: 'ING',
-				description: 'Select your bank. BLZ and FinTS URL will be set automatically.',
-				name: 'bank',
-				options: bankOptions,
-				type: 'options',
-			},
-			{
-				displayName: 'Expert Mode: Enter BLZ and FinTS URL Manually',
-				name: 'expertMode',
-				type: 'boolean',
-				default: false,
-			},
-			{
-				displayName: 'Bank Code (BLZ)',
-				name: 'blz',
-				type: 'string',
-				default: '',
-				displayOptions: {
-					show: {
-						expertMode: [true],
-					},
-				},
-			},
-			{
-				displayName: 'FinTS Server URL',
-				name: 'fintsUrl',
-				type: 'string',
-				default: '',
-				displayOptions: {
-					show: {
-						expertMode: [true],
-					},
-				},
-			},
-			{
-				displayName: 'FinTS Registration Number',
-				name: 'fintsProductId',
-				type: 'string',
-				default: '',
-				description:
-					'The FinTS Product ID to use. Whether this field is required depends on the bank. Please try leaving it empty at first. If you receive an error with code 9050, the bank requires registration for usage.',
-			},
-			{
-				displayName: 'Start Date',
-				name: 'startDate',
-				type: 'dateTime',
-				default: '',
-				description: 'Fetch statements starting from this date. Defaults to 14 days ago.',
-			},
-			{
-				displayName: 'End Date',
-				name: 'endDate',
-				type: 'dateTime',
-				default: '',
-				description: 'Fetch statements up to this date. Defaults to today.',
-			},
-		],
+                properties: [
+                        {
+                                displayName: 'Resource',
+                                name: 'resource',
+                                type: 'options',
+                                default: 'account',
+                                noDataExpression: true,
+                                options: [
+                                        {
+                                                name: 'Account',
+                                                value: 'account',
+                                        },
+                                ],
+                        },
+                        {
+                                displayName: 'Operation',
+                                name: 'operation',
+                                type: 'options',
+                                default: 'getStatements',
+                                noDataExpression: true,
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                        },
+                                },
+                                options: [
+                                        {
+                                                name: 'Get Statements',
+                                                value: 'getStatements',
+                                                action: 'Get statements',
+                                                description:
+                                                        'Retrieve balances and recent transactions for the connected FinTS accounts',
+                                                routing: {
+                                                        send: {
+                                                                preSend: [prepareFintsRequest],
+                                                        },
+                                                        operations: {
+                                                                pagination: runAccountStatementRequest,
+                                                        },
+                                                        output: {
+                                                                postReceive: [attachPairedItem],
+                                                        },
+                                                },
+                                        },
+                                ],
+                        },
+                        {
+                                displayName: 'Select Bank',
+                                name: 'bank',
+                                type: 'options',
+                                default: 'ING',
+                                description: 'Select your bank. BLZ and FinTS URL will be set automatically.',
+                                options: bankOptions,
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                                expertMode: [false],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Expert Mode: Enter BLZ and FinTS URL Manually',
+                                name: 'expertMode',
+                                type: 'boolean',
+                                default: false,
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Bank Code (BLZ)',
+                                name: 'blz',
+                                type: 'string',
+                                default: '',
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                                expertMode: [true],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'FinTS Server URL',
+                                name: 'fintsUrl',
+                                type: 'string',
+                                default: '',
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                                expertMode: [true],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'FinTS Registration Number',
+                                name: 'fintsProductId',
+                                type: 'string',
+                                default: '',
+                                description:
+                                        'The FinTS Product ID to use. Whether this field is required depends on the bank. Please try leaving it empty at first. If you receive an error with code 9050, the bank requires registration for usage.',
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Start Date',
+                                name: 'startDate',
+                                type: 'dateTime',
+                                default: '',
+                                description: 'Fetch statements starting from this date. Defaults to 14 days ago.',
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'End Date',
+                                name: 'endDate',
+                                type: 'dateTime',
+                                default: '',
+                                description: 'Fetch statements up to this date. Defaults to today.',
+                                displayOptions: {
+                                        show: {
+                                                resource: ['account'],
+                                                operation: ['getStatements'],
+                                        },
+                                },
+                        },
+                ],
 		version: 1,
 	};
-
-	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		const credentials = await this.getCredentials('fintsApi');
-
-		let blz: string;
-		let fintsUrl: string;
-
-		const expertMode = this.getNodeParameter('expertMode', 0) as boolean;
-
-		if (expertMode) {
-			blz = this.getNodeParameter('blz', 0) as string;
-			fintsUrl = this.getNodeParameter('fintsUrl', 0) as string;
-		} else {
-			const bank = this.getNodeParameter('bank', 0) as string;
-			const entry = bankMap[bank];
-			if (!entry) {
-				throw new NodeOperationError(this.getNode(), `Unknown bank: ${bank}`);
-			}
-			blz = entry.blz;
-			fintsUrl = entry.fintsUrl;
-		}
-
-		const startDateStr = this.getNodeParameter('startDate', 0, '') as string;
-		const endDateStr = this.getNodeParameter('endDate', 0, '') as string;
-
-		let fintsProductId = this.getNodeParameter('fintsProductId', 0) as string;
-
-		const startDate = startDateStr
-			? new Date(startDateStr)
-			: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
-		const endDate = endDateStr ? new Date(endDateStr) : new Date();
-
-		const userId = credentials.userId as string;
-		const pin = credentials.pin as string;
-
-		const configPinTanClient: PinTanClientConfig = {
-			url: fintsUrl,
-			name: userId,
-			pin,
-			blz,
-		};
-
-		if (fintsProductId.length > 0) {
-			configPinTanClient.productId = fintsProductId;
-		}
-
-		const client = new PinTanClient(configPinTanClient);
-
-		const accounts = await client.accounts();
-		if (!accounts || accounts.length === 0) {
-			throw new NodeOperationError(this.getNode(), 'No Accounts found');
-		}
-
-		const results = [] as Array<{
-			account: string | null;
-			bank: string;
-			balance: number | null;
-			currency: string | null;
-			transactions: Array<any>;
-		}>;
-		for (const account of accounts) {
-			try {
-				const statements = await client.statements(account, startDate, endDate);
-
-				let balance = null;
-				let currency = null;
-				let transactions: Array<any> = [];
-
-				if (statements && statements.length > 0) {
-					const latest = statements[0];
-					balance = (latest.closingBalance && latest.closingBalance.value) || null;
-
-					currency = (latest.closingBalance && latest.closingBalance.currency) || null;
-					transactions = latest.transactions.flatMap((t) => {
-						const text =
-							t.descriptionStructured?.name !== ' '
-								? t.descriptionStructured?.name
-								: t.descriptionStructured?.text;
-
-						return {
-							currency: t.currency,
-							amount: t.isCredit ? t.amount : -t.amount,
-							valueDate: t.valueDate,
-							text,
-							reference: t.bankReference,
-							isCredit: t.isCredit,
-							isExpense: t.isExpense,
-						};
-					});
-				}
-
-				results.push({
-					account: account.iban || account.accountNumber || null,
-					bank: blz,
-					balance,
-					currency,
-					transactions,
-				});
-			} catch (e) {
-				// Could not get the balance for this account.
-				// This is normal for some account types (e.g. securities/stock depots),
-				// since those accounts do not provide a balance via FinTS.
-				// Continue processing the remaining accounts.
-				if (this.logger) {
-					this.logger.warn((e as Error).message);
-				}
-			}
-		}
-
-		return [this.helpers.returnJsonArray(results)];
-	}
 }


### PR DESCRIPTION
## Summary
- convert the FinTS node to a declarative resource/operation selector with routing metadata
- add helper logic invoked from preSend/pagination hooks to perform FinTS requests and shape responses

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cf277cbd548331bb9efb727c0be7ed